### PR TITLE
Support registering of scripts for use in the footer

### DIFF
--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -638,7 +638,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['footer']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_script(
@@ -692,7 +693,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['footer']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_script(


### PR DESCRIPTION
The `wp_register_script` method supports `$in_footer` so that you can setup a footer script and just call `wp_enqueue_script( 'slug' )` when needed.
Reference: https://developer.wordpress.org/reference/functions/wp_register_script/

This change updates the WordPress-MVC add_asset approach to support $in_footer on registered scripts.