### PR TITLE
Update add_asset to use flag instead of footer as it can also mean media

### DIFF
--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -431,7 +431,7 @@ abstract class Bridge implements Plugable
             'path'      => $asset,
             'enqueue'   => $enqueue,
             'dep'       => $dep,
-            'flag'    => $flag,
+            'flag'      => $flag,
             'is_admin'  => $is_admin,
             'version'   => $version,
             'name_id'   => $name_id,
@@ -874,12 +874,11 @@ abstract class Bridge implements Plugable
                 : __DIR__;
             foreach ( $this->config->get( 'autoenqueue.assets' ) as $asset ) {
                 if ( $file->exists( assets_path( $asset['asset'], $dir ) ) ) {
-                    $flag = $asset['flag'] ? $asset['flag'] : $asset['footer'];
                     $this->add_asset(
                         $asset['asset'],
                         array_key_exists( 'enqueue', $asset ) ? $asset['enqueue'] : true,
                         $asset['dep'],
-                        $flag,
+                        array_key_exists( 'flag', $asset ) ? $asset['flag'] : ( array_key_exists( 'footer', $asset ) ? $asset['footer'] : null ),
                         array_key_exists( 'is_admin', $asset ) ? $asset['is_admin'] : false,
                         array_key_exists( 'version', $asset ) ? $asset['version'] : null,
                         array_key_exists( 'id', $asset ) ? $asset['id'] : null

--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -416,21 +416,22 @@ abstract class Bridge implements Plugable
      * @param string $asset         Asset relative path (within assets forlder).
      * @param bool   $enqueue       Flag that indicates if asset should be enqueued upon registration.
      * @param array  $dep           Dependencies.
-     * @param bool   $footer        Flag that indicates if asset should enqueue at page footer.
+     * @param bool   $flag          Conditional flag. For script assests it indicates it should be enqueued in the footer.
+     *                              For style assests it indicates the media for which it has been defined.
      * @param bool   $is_admin      Flag that indicates if asset should be enqueue on admin.
      * @param string $version       Asset version.
      * @param string $name_id       Asset name ID (slug).
      * @
      */
-    public function add_asset( $asset, $enqueue = true, $dep = [], $footer = null, $is_admin = false, $version = null, $name_id = null )
+    public function add_asset( $asset, $enqueue = true, $dep = [], $flag = null, $is_admin = false, $version = null, $name_id = null )
     {
-        if ( $footer === null )
-            $footer = preg_match( '/\.js/', $asset );
+        if ( $flag === null )
+            $flag = preg_match( '/\.js/', $asset );
         $this->assets[] = [
             'path'      => $asset,
             'enqueue'   => $enqueue,
             'dep'       => $dep,
-            'footer'    => $footer,
+            'flag'    => $flag,
             'is_admin'  => $is_admin,
             'version'   => $version,
             'name_id'   => $name_id,
@@ -621,7 +622,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['flag']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_style(
@@ -629,7 +631,7 @@ abstract class Bridge implements Plugable
                         assets_url( $asset['path'], $dir ),
                         $asset['dep'],
                         $asset_version,
-                        $asset['footer']
+                        $asset['flag']
                     );
             }
             // Scripts
@@ -638,7 +640,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['flag']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_script(
@@ -646,7 +649,7 @@ abstract class Bridge implements Plugable
                         assets_url( $asset['path'], $dir ),
                         $asset['dep'],
                         $asset_version,
-                        $asset['footer']
+                        $asset['flag']
                     );
             }
         }
@@ -675,7 +678,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['flag']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_style(
@@ -683,7 +687,7 @@ abstract class Bridge implements Plugable
                         assets_url( $asset['path'], $dir ),
                         $asset['dep'],
                         $asset_version,
-                        $asset['footer']
+                        $asset['flag']
                     );
             }
             // Scripts
@@ -692,7 +696,8 @@ abstract class Bridge implements Plugable
                     $name,
                     assets_url( $asset['path'], $dir ),
                     $asset['dep'],
-                    $asset_version
+                    $asset_version,
+                    $asset['flag']
                 );
                 if ($asset['enqueue'])
                     wp_enqueue_script(
@@ -700,7 +705,7 @@ abstract class Bridge implements Plugable
                         assets_url( $asset['path'], $dir ),
                         $asset['dep'],
                         $asset_version,
-                        $asset['footer']
+                        $asset['flag']
                     );
             }
         }
@@ -868,16 +873,18 @@ abstract class Bridge implements Plugable
                 ? $this->config->get( 'paths.base' )
                 : __DIR__;
             foreach ( $this->config->get( 'autoenqueue.assets' ) as $asset ) {
-                if ( $file->exists( assets_path( $asset['asset'], $dir ) ) )
+                if ( $file->exists( assets_path( $asset['asset'], $dir ) ) ) {
+                    $flag = $asset['flag'] ? $asset['flag'] : $asset['footer'];
                     $this->add_asset(
                         $asset['asset'],
                         array_key_exists( 'enqueue', $asset ) ? $asset['enqueue'] : true,
                         $asset['dep'],
-                        $asset['footer'],
+                        $flag,
                         array_key_exists( 'is_admin', $asset ) ? $asset['is_admin'] : false,
                         array_key_exists( 'version', $asset ) ? $asset['version'] : null,
                         array_key_exists( 'id', $asset ) ? $asset['id'] : null
                     );
+                }
             }
         }
     }


### PR DESCRIPTION
As the add_asset is used on both scripts and styles the use of $footer is confusing as styles use $media.
`wp_register_script( string $handle, string|bool $src, string[] $deps = array(), string|bool|null $ver = false, bool $in_footer = false )`
`wp_register_style( string $handle, string|bool $src, string[] $deps = array(), string|bool|null $ver = false, string $media = 'all' )`
*The same goes for `wp_enqueue_script` & `wp_enqueue_style`

This patch updates the use to switch to $flag for the add_asset function. 

I provided back-compat w/ footer on the `autoenqueue.assets` as it's used for autoenqueuing as found here;
https://www.wordpress-mvc.com/v1/assets/
*If this is accepted we should change the documentation for the autoenqueue to use 'flag'