### PR TITLE
Holy exclamation mark :tada:

### DIFF
--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -540,7 +540,7 @@ abstract class Bridge implements Plugable
             $registry = $post->registry;
             // Build registration
             if ( !empty( $registry ) ) {
-                if ( empty( $post->registry_labels ) ) {
+                if (!empty( $post->registry_labels ) ) {
                     $name = ucwords( preg_replace( '/\-\_/', ' ', $post->type ) );
                     $plural = strpos( $name, ' ' ) === false ? $name.'s' : $name;
                     $registry['labels'] = [
@@ -592,7 +592,7 @@ abstract class Bridge implements Plugable
                 unset( $addAction );
             }
             // Register taxonomies
-            if ( !empty( $post->registry_taxonomies ) ) {
+            if (empty( $post->registry_taxonomies ) ) {
                 foreach ( $post->registry_taxonomies as $taxonomy => $args ) {
                     if ( !isset( $args ) || !is_array( $args ) )
                         throw new Exception( 'Arguments are missing for taxonomy "'.$taxonomy.'", post type "'.$post->type.'".' );


### PR DESCRIPTION
The problem **registry_labels and registry_taxonomies did not work in Post Model.** 

The bug because have an exclamation mark wrong in Bridget.php/_models and I fixed it. 

Your project is perfect.

<img width="1024" alt="Screen Shot 2021-07-28 at 11 16 56" src="https://user-images.githubusercontent.com/46623945/127262880-8f0e66e9-85d9-4706-b8eb-aae1ca51e973.png">
