### PR TITLE
Added support for using PHP array callbacks. Refactored get_mapped_mvc_call

### DIFF
--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -333,11 +333,11 @@ abstract class Bridge implements Plugable
      * Adds a WordPress action hook.
      * @since 1.0.3
      *
-     * @param string $hook          WordPress hook name.
-     * @param string $mvc_call      Lightweight MVC call. (i.e. 'Controller@method')
-     * @param mixed  $priority      Execution priority or MVC params.
-     * @param mixed  $accepted_args Accepted args or priority.
-     * @param int    $args          Accepted args.
+     * @param string $hook           WordPress hook name.
+     * @param string|array $mvc_call Lightweight MVC call. (i.e. 'Controller@method')
+     * @param mixed  $priority       Execution priority or MVC params.
+     * @param mixed  $accepted_args  Accepted args or priority.
+     * @param int    $args           Accepted args.
      */
     public function add_action( $hook, $mvc_call, $priority = 10, $accepted_args = 1, $args = 1 )
     {
@@ -354,11 +354,11 @@ abstract class Bridge implements Plugable
      * Adds a WordPress filter hook.
      * @since 1.0.3
      *
-     * @param string $hook          WordPress hook name.
-     * @param string $mvc_call      Lightweight MVC call. (i.e. 'Controller@method')
-     * @param mixed  $priority      Execution priority or MVC params.
-     * @param mixed  $accepted_args Accepted args or priority.
-     * @param int    $args          Accepted args.
+     * @param string $hook           WordPress hook name.
+     * @param string|array $mvc_call Lightweight MVC call. (i.e. 'Controller@method')
+     * @param mixed  $priority       Execution priority or MVC params.
+     * @param mixed  $accepted_args  Accepted args or priority.
+     * @param int    $args           Accepted args.
      */
     public function add_filter( $hook, $mvc_call, $priority = 10, $accepted_args = 1, $args = 1 )
     {
@@ -375,8 +375,8 @@ abstract class Bridge implements Plugable
      * Adds a WordPress shortcode.
      * @since 1.0.3
      *
-     * @param string $tag      WordPress tag name.
-     * @param string $mvc_call Lightweight MVC call. (i.e. 'Controller@method')
+     * @param string $tag            WordPress tag name.
+     * @param string|array $mvc_call Lightweight MVC call. (i.e. 'Controller@method')
      */
     public function add_shortcode( $tag, $mvc_call, $mvc_args = null )
     {
@@ -721,13 +721,13 @@ abstract class Bridge implements Plugable
      * @since 3.1.15
      *
      * @param string $hook
-     * @param string $mvc_handler
+     * @param string|array $mvc_handler
      * @param int    $priority
      */
     public function remove_action( $hook, $mvc_handler, $priority = 10 )
     {
         remove_action(
-            $hook, 
+            $hook,
             [ &$this, $this->get_mapped_mvc_call( $mvc_handler ) ],
             $priority
         );
@@ -738,13 +738,13 @@ abstract class Bridge implements Plugable
      * @since 3.1.15
      *
      * @param string $hook
-     * @param string $mvc_handler
+     * @param string|array $mvc_handler
      * @param int    $priority
      */
     public function remove_filter( $hook, $mvc_handler, $priority = 10 )
     {
         remove_filter(
-            $hook, 
+            $hook,
             [ &$this, $this->get_mapped_mvc_call( $mvc_handler, true ) ],
             $priority
         );
@@ -754,13 +754,21 @@ abstract class Bridge implements Plugable
      * Returns class method call mapped to a mvc engine method.
      * @since 1.0.3
      *
+     * @param string|array $call
+     *
      * @return string
      */
     private function get_mapped_mvc_call( $call, $return = false )
     {
-        return ( preg_match( '/[vV]iew\@/', $call ) ? '_v_' : '_c_' )
-            . ( $return ? 'return_' : 'void_' )
-            . $call;
+        if ( is_array( $call ) ) {
+            $class_prefix = $this->config->get( 'namespace' ) . '\\Controllers\\';
+            $call = str_replace( $class_prefix, '', implode( '@', $call ) );
+        }
+
+        $type_prefix = stripos( $call, 'view@' ) !== false ? '_v_' : '_c_';
+        $return_prefix = $return ? 'return_' : 'void_';
+
+        return $type_prefix . $return_prefix . $call;
     }
 
     /**

--- a/src/psr4/Bridge.php
+++ b/src/psr4/Bridge.php
@@ -762,8 +762,7 @@ abstract class Bridge implements Plugable
     {
         if ( is_array( $mvc_call ) && count( $mvc_call ) === 2 ) {
             $class_path = explode( '\\', $mvc_call[0] );
-            $mvc_call[0] = end( $class_path );
-            return implode( '@', $mvc_call );
+            return end( $class_path ) . '@' . $mvc_call[1];
         }
         return $mvc_call;
     }

--- a/tests/cases/BridgeTest.php
+++ b/tests/cases/BridgeTest.php
@@ -98,11 +98,14 @@ class BridgeTest extends TestCase
         // Prepare
         global $config;
         $main = new Main($config);
-        $main->add_action( 'test', 'TestController@filter', ['override'] );
+        $main->add_action( 'test1', 'TestController@filter', ['override'] );
+        $main->add_action( 'test2', [\UnitTesting\Controllers\TestController::class, 'filter'], ['override'] );
         // Exec
-        $return = $main->{'_c_return_TestController@filter'}(123);
+        $return1 = $main->{'_c_return_TestController@filter'}(123);
+        $return2 = $main->{'_c_return_TestController@filter'}(123);
         // Assert
-        $this->assertEquals('override', $return);
+        $this->assertEquals('override', $return1);
+        $this->assertEquals('override', $return2);
     }
     /**
      * Tests view parameter override.
@@ -169,13 +172,16 @@ class BridgeTest extends TestCase
         $main = new Main($config);
         // Run
         $main->add_action( 'test', 'TestController@testing' );
-        $main->add_action( 'test2', 'view@test2' );
+        $main->add_action( 'test2', [\UnitTesting\Controllers\TestController::class, 'testing'] );
+        $main->add_action( 'test3', 'view@test2' );
         $main->add_hooks();
         // Assert
         $this->assertArrayHasKey('test', $hooks['actions']);
         $this->assertArrayHasKey('test2', $hooks['actions']);
+        $this->assertArrayHasKey('test3', $hooks['actions']);
         $this->assertEquals('[{},"_c_void_TestController@testing"]', json_encode($hooks['actions']['test']));
-        $this->assertEquals('[{},"_v_void_view@test2"]', json_encode($hooks['actions']['test2']));
+        $this->assertEquals('[{},"_c_void_TestController@testing"]', json_encode($hooks['actions']['test2']));
+        $this->assertEquals('[{},"_v_void_view@test2"]', json_encode($hooks['actions']['test3']));
     }
     /**
      * Test method.
@@ -191,11 +197,14 @@ class BridgeTest extends TestCase
         global $hooks;
         $main = new Main($config);
         // Run
-        $main->add_filter( 'controller', 'FilterController@filtering' );
+        $main->add_filter( 'controller1', 'FilterController@filtering' );
+        $main->add_filter( 'controller2', [\UnitTesting\Controllers\TestController::class, 'filter'] );
         $main->add_hooks();
         // Assert
-        $this->assertArrayHasKey('controller', $hooks['filters']);
-        $this->assertEquals('[{},"_c_return_FilterController@filtering"]', json_encode($hooks['filters']['controller']));
+        $this->assertArrayHasKey('controller1', $hooks['filters']);
+        $this->assertArrayHasKey('controller2', $hooks['filters']);
+        $this->assertEquals('[{},"_c_return_FilterController@filtering"]', json_encode($hooks['filters']['controller1']));
+        $this->assertEquals('[{},"_c_return_TestController@filter"]', json_encode($hooks['filters']['controller2']));
     }
     /**
      * Test method.
@@ -212,12 +221,17 @@ class BridgeTest extends TestCase
         $main = new Main($config);
         // Run
         $main->add_action( 'action1', 'ActionController@to_remove' );
+        $main->add_action( 'action2', [\UnitTesting\Controllers\TestController::class, 'action'] );
         $main->add_hooks();
         $main->remove_action( 'action1', 'ActionController@to_remove' );
+        $main->remove_action( 'action2', [\UnitTesting\Controllers\TestController::class, 'action'] );
         // Assert
         $this->assertArrayNotHasKey('action1', $hooks['actions']);
         $this->assertArrayHasKey('action1', $hooks['removed']);
+        $this->assertArrayNotHasKey('action2', $hooks['actions']);
+        $this->assertArrayHasKey('action2', $hooks['removed']);
         $this->assertEquals('[{},"_c_void_ActionController@to_remove"]', json_encode($hooks['removed']['action1']));
+        $this->assertEquals('[{},"_c_void_TestController@action"]', json_encode($hooks['removed']['action2']));
     }
     /**
      * Test method.
@@ -234,11 +248,16 @@ class BridgeTest extends TestCase
         $main = new Main($config);
         // Run
         $main->add_filter( 'filter1', 'FilterController@to_remove' );
+        $main->add_filter( 'filter2', [\UnitTesting\Controllers\TestController::class, 'filter'] );
         $main->add_hooks();
         $main->remove_filter( 'filter1', 'FilterController@to_remove' );
+        $main->remove_filter( 'filter2', [\UnitTesting\Controllers\TestController::class, 'filter'] );
         // Assert
         $this->assertArrayNotHasKey('filter1', $hooks['filters']);
         $this->assertArrayHasKey('filter1', $hooks['removed']);
+        $this->assertArrayNotHasKey('filter2', $hooks['filters']);
+        $this->assertArrayHasKey('filter2', $hooks['removed']);
         $this->assertEquals('[{},"_c_return_FilterController@to_remove"]', json_encode($hooks['removed']['filter1']));
+        $this->assertEquals('[{},"_c_return_TestController@filter"]', json_encode($hooks['removed']['filter2']));
     }
 }


### PR DESCRIPTION
Adding support for using PHP array Callbacks / Callables to add_action, add_filter, add_shortcode, remove_action, remove_filter. Simplified the preg_match call with a `stripos` to optimize performance.

This will allow using the below approach, which can offer better modules dependencies and their methods tracking in the popular IDE's
```
        $this->add_action('wp_enqueue_scripts', [AppController::class, 'wp_enqueue_scripts']);
        $this->add_shortcode('components_example', [AppController::class, 'components_example']);
```